### PR TITLE
Remove one comma to babel7/ecma rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ export default class extends Component {
             children,
             useAnimatedScrollView,
             useKeyboardAvoidingView,
-            ...otherProps,
+            ...otherProps
         } = this.props;
 
         const {


### PR DESCRIPTION
trailing commas are not allowed in function params after rest elements.
https://stackoverflow.com/questions/54282836/object-rest-spread-is-not-allowed-trailing-commas-in-babel-7